### PR TITLE
Add/display design name on listing and more (see description).

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -155,32 +155,33 @@ body.mystyle-design-profile ul.mystyle-designs li a:hover {
 body.mystyle-design-profile ul.mystyle-designs li span.mystyle-design-id {
     display: block;
 }
+
 /*list/grid styling code start*/
 .product_description {
     margin-bottom: 60px;
 }
-.customize_products.list_view ul.products.columns-3 li img {
+.customize_products.list_view ul.products li img {
     display: none;
 }
-.customize_products.list_view ul.products.columns-3 li {
+.customize_products.list_view ul.products li {
     display: block;
     width: 100% !important;
     text-align: left;
 }
-.customize_products.list_view ul.products.columns-3 li h2 {
+.customize_products.list_view ul.products li h2 {
     float: left;
 }
-.customize_products.list_view ul.products.columns-3 li .price {
+.customize_products.list_view ul.products li .price {
     display: inline-block;
     margin-left: 10px;
 }  
-.customize_products.list_view ul.products.columns-3 li span.onsale {
+.customize_products.list_view ul.products li span.onsale {
     display: none;
 }
-.customize_products.list_view ul.products.columns-3 li a {
+.customize_products.list_view ul.products li a {
     float: left;
 }
-.customize_products.list_view ul.products.columns-3 li a.button.add_to_cart_button {
+.customize_products.list_view ul.products li a.button.add_to_cart_button {
     margin-left: 10px;
     position: relative;
     bottom: 7px;

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -157,31 +157,31 @@ body.mystyle-design-profile ul.mystyle-designs li span.mystyle-design-id {
 }
 
 /*list/grid styling code start*/
-.product_description {
+#mystyle-design-profile-wrapper .product_description {
     margin-bottom: 60px;
 }
-.customize_products.list_view ul.products li img {
+#mystyle-design-profile-wrapper .customize_products.list_view ul.products li img {
     display: none;
 }
-.customize_products.list_view ul.products li {
+#mystyle-design-profile-wrapper .customize_products.list_view ul.products li {
     display: block;
     width: 100% !important;
     text-align: left;
 }
-.customize_products.list_view ul.products li h2 {
+#mystyle-design-profile-wrapper .customize_products.list_view ul.products li h2 {
     float: left;
 }
-.customize_products.list_view ul.products li .price {
+#mystyle-design-profile-wrapper .customize_products.list_view ul.products li .price {
     display: inline-block;
     margin-left: 10px;
 }  
-.customize_products.list_view ul.products li span.onsale {
+#mystyle-design-profile-wrapper .customize_products.list_view ul.products li span.onsale {
     display: none;
 }
-.customize_products.list_view ul.products li a {
+#mystyle-design-profile-wrapper .customize_products.list_view ul.products li a {
     float: left;
 }
-.customize_products.list_view ul.products li a.button.add_to_cart_button {
+#mystyle-design-profile-wrapper .customize_products.list_view ul.products li a.button.add_to_cart_button {
     margin-left: 10px;
     position: relative;
     bottom: 7px;

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -155,5 +155,34 @@ body.mystyle-design-profile ul.mystyle-designs li a:hover {
 body.mystyle-design-profile ul.mystyle-designs li span.mystyle-design-id {
     display: block;
 }
-
-
+/*list/grid styling code start*/
+.product_description {
+    margin-bottom: 60px;
+}
+.customize_products.list_view ul.products.columns-3 li img {
+    display: none;
+}
+.customize_products.list_view ul.products.columns-3 li {
+    display: block;
+    width: 100% !important;
+    text-align: left;
+}
+.customize_products.list_view ul.products.columns-3 li h2 {
+    float: left;
+}
+.customize_products.list_view ul.products.columns-3 li .price {
+    display: inline-block;
+    margin-left: 10px;
+}  
+.customize_products.list_view ul.products.columns-3 li span.onsale {
+    display: none;
+}
+.customize_products.list_view ul.products.columns-3 li a {
+    float: left;
+}
+.customize_products.list_view ul.products.columns-3 li a.button.add_to_cart_button {
+    margin-left: 10px;
+    position: relative;
+    bottom: 7px;
+}
+/*list/grid styling code end*/

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -137,8 +137,8 @@ body.mystyle-design-profile ul.mystyle-designs {
 body.mystyle-design-profile ul.mystyle-designs li {
     display: inline-block;
     margin: 1em;
+    max-width: 300px;
 }
-
 body.mystyle-design-profile ul.mystyle-designs li a {
     display: block;
     padding: 2em;

--- a/includes/admin/pages/class-mystyle-options-page.php
+++ b/includes/admin/pages/class-mystyle-options-page.php
@@ -91,9 +91,9 @@ class MyStyle_Options_Page {
 		);
 
 		add_settings_field(
-			'layout_view', 'Layout Views', array(&$this, 'render_layout_view'), 'mystyle_advanced_settings', 'mystyle_options_advanced_section'
+			'layout_view', 'Layout View', array(&$this, 'render_layout_view'), 'mystyle_advanced_settings', 'mystyle_options_advanced_section'
 		);
-				
+
 		// ************** TOOLS SECTION ******************//
 		add_settings_section(
 				'mystyle_options_tools_section', 'MyStyle Tools', array(&$this, 'render_tools_section_text'), 'mystyle_tools'

--- a/includes/admin/pages/class-mystyle-options-page.php
+++ b/includes/admin/pages/class-mystyle-options-page.php
@@ -90,6 +90,10 @@ class MyStyle_Options_Page {
 				'enable_configur8', 'Enable Configur8', array(&$this, 'render_enable_configur8'), 'mystyle_advanced_settings', 'mystyle_options_advanced_section'
 		);
 
+		add_settings_field(
+			'layout_view', 'Layout Views', array(&$this, 'render_layout_view'), 'mystyle_advanced_settings', 'mystyle_options_advanced_section'
+		);
+				
 		// ************** TOOLS SECTION ******************//
 		add_settings_section(
 				'mystyle_options_tools_section', 'MyStyle Tools', array(&$this, 'render_tools_section_text'), 'mystyle_tools'
@@ -387,6 +391,32 @@ class MyStyle_Options_Page {
 	}
 
 	/**
+	 * Function to render the Layout View option
+	 * and select.
+	 */
+	public function render_layout_view() {
+		$options = get_option(MYSTYLE_OPTIONS_NAME, array());
+		$layout_view = ( array_key_exists('layout_view', $options) ) ? $options['layout_view'] :""; ?>
+		<label class="description">
+			<select name="mystyle_options[layout_view]">
+			<?php 
+				$select  = array('grid_view' => 'Grid View' ,'list_view' => 'List View');
+				foreach ( $select as $key => $value ) {
+					if( $key  == $layout_view ) {
+						$selected = "selected";
+					}else{
+						$selected = "";
+					}
+					echo '<option value="'.$key.'"'.$selected.' >'.$value.'</option>';	
+				}
+			?>
+			</select>
+		</label>
+		<p class="description"></p>
+		<?php
+	}
+
+	/**
 	 * Function to render the text for the tools section.
 	 */
 	public function render_tools_section_text() {
@@ -478,6 +508,10 @@ class MyStyle_Options_Page {
 			$msg_message = 'Invalid Enable Alternate Design Complete Redirect option';
 			$new_options['enable_alternate_design_complete_redirect'] = 0;
 		}
+
+		//Grid/List layout option.
+		$new_options['layout_view'] = trim( $input['layout_view'] );
+
 
 		//Alternate Design Complete Redirect URL
 		$new_options['alternate_design_complete_redirect_url'] = trim($input['alternate_design_complete_redirect_url']);

--- a/includes/admin/pages/class-mystyle-options-page.php
+++ b/includes/admin/pages/class-mystyle-options-page.php
@@ -400,7 +400,7 @@ class MyStyle_Options_Page {
 		<label class="description">
 			<select name="mystyle_options[layout_view]">
 			<?php 
-				$select  = array('grid_view' => 'Grid View' ,'list_view' => 'List View');
+				$select  = array('list_view' => 'List View', 'grid_view' => 'Grid View');
 				foreach ( $select as $key => $value ) {
 					if( $key  == $layout_view ) {
 						$selected = "selected";

--- a/includes/admin/pages/class-mystyle-options-page.php
+++ b/includes/admin/pages/class-mystyle-options-page.php
@@ -91,7 +91,7 @@ class MyStyle_Options_Page {
 		);
 
 		add_settings_field(
-			'layout_view', 'Layout View', array(&$this, 'render_layout_view'), 'mystyle_advanced_settings', 'mystyle_options_advanced_section'
+				'layout_view', 'Reload-To-Other-Product Menu Style', array(&$this, 'render_layout_view'), 'mystyle_advanced_settings', 'mystyle_options_advanced_section'
 		);
 
 		// ************** TOOLS SECTION ******************//
@@ -400,7 +400,7 @@ class MyStyle_Options_Page {
 		<label class="description">
 			<select name="mystyle_options[layout_view]">
 			<?php 
-				$select  = array('list_view' => 'List View', 'grid_view' => 'Grid View');
+				$select  = array('list_view' => 'List View', 'grid_view' => 'Grid View' , 'disabled' => 'Disabled');
 				foreach ( $select as $key => $value ) {
 					if( $key  == $layout_view ) {
 						$selected = "selected";
@@ -411,9 +411,10 @@ class MyStyle_Options_Page {
 				}
 			?>
 			</select>
+			<p class="description">The menu on the design profile page listing all custom products to reload the design on.</p>
 		</label>
-		<p class="description"></p>
 		<?php
+
 	}
 
 	/**

--- a/includes/class-mystyle-options.php
+++ b/includes/class-mystyle-options.php
@@ -199,10 +199,11 @@ abstract class MyStyle_Options {
 	 * otherwise returns list.
 	 */
 	static function get_layout_view() {
-		$val = null;
 		$options = get_option( MYSTYLE_OPTIONS_NAME, array() );
 		if ( ! empty( $options['layout_views'] ) ) {
 			$val = $options['layout_views'];
+		}else{
+			$val = 'list_view';
 		}
 		return $val;
 	}

--- a/includes/class-mystyle-options.php
+++ b/includes/class-mystyle-options.php
@@ -200,8 +200,8 @@ abstract class MyStyle_Options {
 	 */
 	static function get_layout_view() {
 		$options = get_option( MYSTYLE_OPTIONS_NAME, array() );
-		if ( ! empty( $options['layout_views'] ) ) {
-			$val = $options['layout_views'];
+		if ( ! empty( $options['layout_view'] ) ) {
+			$val = $options['layout_view'];
 		}else{
 			$val = 'list_view';
 		}

--- a/includes/class-mystyle-options.php
+++ b/includes/class-mystyle-options.php
@@ -194,6 +194,20 @@ abstract class MyStyle_Options {
 	}
 
 	/**
+	 * Function that gets the value of the layout_view option.
+	 * @return grid if Grid vew selected,
+	 * otherwise returns list.
+	 */
+	static function get_layout_view() {
+		$val = null;
+		$options = get_option( MYSTYLE_OPTIONS_NAME, array() );
+		if ( ! empty( $options['layout_views'] ) ) {
+			$val = $options['layout_views'];
+		}
+		return $val;
+	}
+
+	/**
 	 * Determines whether or not the passed option is enabled.
 	 * @param string $option_name The name of the option. This is passed to
 	 * WordPress's get_option function.

--- a/includes/entities/class-mystyle-design.php
+++ b/includes/entities/class-mystyle-design.php
@@ -681,6 +681,35 @@ class MyStyle_Design implements MyStyle_Entity {
 	}
 
 	/**
+	 * Build the scratch url to the customizer for the design.
+	 */
+	public function get_scratch_url() {
+		$customize_page_id = MyStyle_Customize_Page::get_id();
+
+		$passthru = array();
+		$passthru['post'] = null;
+
+		if ($this->cart_data != null) {
+			$post_data = json_decode($this->cart_data, true);
+		} else {
+			//set some default post/cart data
+			$post_data = array(
+				'quantity' => 1,
+				'add-to-cart' => $this->product_id,
+			);
+		}
+		$passthru['post'] = $post_data;
+		$passthru_encoded = base64_encode(json_encode($passthru));
+		$customize_args = array(
+			'product_id' => $this->product_id,
+			'h' => $passthru_encoded,
+		);
+		$customizer_url = add_query_arg($customize_args, get_permalink($customize_page_id));
+
+		return $customizer_url;
+	}
+	
+	/**
 	 * Get URL that will add the design to the cart and then show the cart. This
 	 * is used for adding designs from the design profile page to the cart.
 	 * @global type $woocommerce

--- a/includes/entities/class-mystyle-design.php
+++ b/includes/entities/class-mystyle-design.php
@@ -23,7 +23,6 @@ class MyStyle_Design implements MyStyle_Entity {
 	private $thumb_url;
 	private $design_url;
 	private $template_id; //this is the MyStyle product id
-	private $design_title; //this is the MyStyle product Title
 	private $product_id; //this is the local product id
 	private $user_id; //this is the local (WordPress) user id (if the user designer has one)
 	private $designer_id; //the mystyle user id
@@ -69,7 +68,6 @@ class MyStyle_Design implements MyStyle_Entity {
 		$instance->design_id = (int) htmlspecialchars($post_data['design_id']);
 		$instance->template_id = (int) htmlspecialchars($post_data['product_id']); //mapping product_id to template_id
 		$instance->designer_id = (int) htmlspecialchars($post_data['user_id']);
-		$instance->design_title = htmlspecialchars($post_data['design_title']);
 		$instance->cart_data = json_encode($passthru_post);
 
 		//these aren't always passed (or may be deprecated)
@@ -99,7 +97,6 @@ class MyStyle_Design implements MyStyle_Entity {
 
 		$instance->design_id = (int) htmlspecialchars($result_object->ms_design_id);
 		$instance->template_id = (int) htmlspecialchars($result_object->ms_product_id);
-		$instance->design_title = htmlspecialchars($result_object->ms_design_title);
 		$instance->designer_id = (int) htmlspecialchars($result_object->ms_user_id);
 		$instance->email = htmlspecialchars($result_object->ms_email);
 		$instance->description = htmlspecialchars($result_object->ms_description);
@@ -143,7 +140,6 @@ class MyStyle_Design implements MyStyle_Entity {
 
 		$instance->design_id = (int) htmlspecialchars($result_array['ms_design_id']);
 		$instance->template_id = (int) htmlspecialchars($result_array['ms_product_id']);
-		$instance->design_title = htmlspecialchars($result_array['ms_design_title']);
 		$instance->designer_id = (int) htmlspecialchars($result_array['ms_user_id']);
 		$instance->email = htmlspecialchars($result_array['ms_email']);
 		$instance->description = htmlspecialchars($result_array['ms_description']);
@@ -324,23 +320,6 @@ class MyStyle_Design implements MyStyle_Entity {
 	 */
 	public function get_template_id() {
 		return $this->template_id;
-	}
-
-
-	/**
-	 * Sets the value of design_title.
-	 * @param number $design_title The new value for design_title.
-	 */
-	public function set_design_title($design_title) {
-		$this->design_title = $design_title;
-	}
-
-	/**
-	 * Gets the value of design_title.
-	 * @return number Returns the value of design_title.
-	 */
-	public function get_design_title() {
-		return $this->design_title;
 	}
 
 	/**
@@ -557,7 +536,6 @@ class MyStyle_Design implements MyStyle_Entity {
 		return "
             CREATE TABLE $table_name (
                 ms_design_id bigint(32) NOT NULL,
-                ms_design_title varchar(255) NULL,
                 ms_product_id bigint(20) NOT NULL,
                 ms_user_id bigint(20) NULL,
                 ms_email varchar(255) NULL,
@@ -611,7 +589,6 @@ class MyStyle_Design implements MyStyle_Entity {
 
 		$data['ms_design_id'] = $this->design_id;
 		$data['ms_product_id'] = $this->template_id;
-		$data['ms_design_title'] = $this->design_title;
 		$data['ms_user_id'] = $this->designer_id;
 		$data['ms_email'] = $this->email;
 		$data['ms_description'] = $this->description;

--- a/includes/entities/class-mystyle-design.php
+++ b/includes/entities/class-mystyle-design.php
@@ -23,6 +23,7 @@ class MyStyle_Design implements MyStyle_Entity {
 	private $thumb_url;
 	private $design_url;
 	private $template_id; //this is the MyStyle product id
+	private $design_title; //this is the MyStyle product Title
 	private $product_id; //this is the local product id
 	private $user_id; //this is the local (WordPress) user id (if the user designer has one)
 	private $designer_id; //the mystyle user id
@@ -68,6 +69,7 @@ class MyStyle_Design implements MyStyle_Entity {
 		$instance->design_id = (int) htmlspecialchars($post_data['design_id']);
 		$instance->template_id = (int) htmlspecialchars($post_data['product_id']); //mapping product_id to template_id
 		$instance->designer_id = (int) htmlspecialchars($post_data['user_id']);
+		$instance->design_title = htmlspecialchars($post_data['design_title']);
 		$instance->cart_data = json_encode($passthru_post);
 
 		//these aren't always passed (or may be deprecated)
@@ -97,6 +99,7 @@ class MyStyle_Design implements MyStyle_Entity {
 
 		$instance->design_id = (int) htmlspecialchars($result_object->ms_design_id);
 		$instance->template_id = (int) htmlspecialchars($result_object->ms_product_id);
+		$instance->design_title = htmlspecialchars($result_object->ms_design_title);
 		$instance->designer_id = (int) htmlspecialchars($result_object->ms_user_id);
 		$instance->email = htmlspecialchars($result_object->ms_email);
 		$instance->description = htmlspecialchars($result_object->ms_description);
@@ -140,6 +143,7 @@ class MyStyle_Design implements MyStyle_Entity {
 
 		$instance->design_id = (int) htmlspecialchars($result_array['ms_design_id']);
 		$instance->template_id = (int) htmlspecialchars($result_array['ms_product_id']);
+		$instance->design_title = htmlspecialchars($result_array['ms_design_title']);
 		$instance->designer_id = (int) htmlspecialchars($result_array['ms_user_id']);
 		$instance->email = htmlspecialchars($result_array['ms_email']);
 		$instance->description = htmlspecialchars($result_array['ms_description']);
@@ -320,6 +324,23 @@ class MyStyle_Design implements MyStyle_Entity {
 	 */
 	public function get_template_id() {
 		return $this->template_id;
+	}
+
+
+	/**
+	 * Sets the value of design_title.
+	 * @param number $design_title The new value for design_title.
+	 */
+	public function set_design_title($design_title) {
+		$this->design_title = $design_title;
+	}
+
+	/**
+	 * Gets the value of design_title.
+	 * @return number Returns the value of design_title.
+	 */
+	public function get_design_title() {
+		return $this->design_title;
 	}
 
 	/**
@@ -536,6 +557,7 @@ class MyStyle_Design implements MyStyle_Entity {
 		return "
             CREATE TABLE $table_name (
                 ms_design_id bigint(32) NOT NULL,
+                ms_design_title varchar(255) NULL,
                 ms_product_id bigint(20) NOT NULL,
                 ms_user_id bigint(20) NULL,
                 ms_email varchar(255) NULL,
@@ -589,6 +611,7 @@ class MyStyle_Design implements MyStyle_Entity {
 
 		$data['ms_design_id'] = $this->design_id;
 		$data['ms_product_id'] = $this->template_id;
+		$data['ms_design_title'] = $this->design_title;
 		$data['ms_user_id'] = $this->designer_id;
 		$data['ms_email'] = $this->email;
 		$data['ms_description'] = $this->description;
@@ -624,6 +647,7 @@ class MyStyle_Design implements MyStyle_Entity {
 		$formats_arr = array(
 			'%d', //ms_design_id
 			'%d', //ms_product_id
+			'%s', //ms_design title
 			'%d', //ms_user_id
 			'%s', //ms_email
 			'%s', //ms_description

--- a/includes/frontend/endpoints/class-mystyle-handoff.php
+++ b/includes/frontend/endpoints/class-mystyle-handoff.php
@@ -114,6 +114,12 @@ class MyStyle_Handoff {
 			//Add data from the user to the design
 			$this->design->set_email($mystyle_user->get_email());
 
+			$design_id = $this->design->get_design_id();
+			$product_id = $this->design->get_product_id();
+			$product = wc_get_product( $product_id );
+			$product_title =  $product->get_title();
+			$this->design->set_design_title("Custom ". $product_title .' '. $design_id);
+
 			//If the user is logged in to WordPress, store their user id with their design
 			$wp_user_id = get_current_user_id();
 			if ($wp_user_id !== 0) {
@@ -262,7 +268,7 @@ class MyStyle_Handoff {
 						( MyStyle_Options::get_alternate_design_complete_redirect_url() != null )
 				) {
 
-					// $link = MyStyle_Options::build_alternate_design_complete_redirect_url($this->design);
+					// $link = MyStyle_Options::build_alternate_design_complete_redirect_url($this->design,$override);
 					$link = MyStyle_Design_Complete::get_redirect_url($this->design);
 					$html = '<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=' . $link . '"></head><body></body></html>';
 				} else {

--- a/includes/frontend/endpoints/class-mystyle-handoff.php
+++ b/includes/frontend/endpoints/class-mystyle-handoff.php
@@ -118,7 +118,6 @@ class MyStyle_Handoff {
 			$product_id = $this->design->get_product_id();
 			$product = wc_get_product( $product_id );
 			$product_title =  $product->get_title();
-			$this->design->set_design_title("Custom ". $product_title .' '. $design_id);
 
 			//If the user is logged in to WordPress, store their user id with their design
 			$wp_user_id = get_current_user_id();

--- a/includes/pages/class-mystyle-design-profile-page.php
+++ b/includes/pages/class-mystyle-design-profile-page.php
@@ -391,9 +391,9 @@ class MyStyle_Design_Profile_Page {
 
 	/**
 	 * Get the product titleas the current design.
-	 */
-	public function get_product_title( $product_id ) {.
 	 * @param MyStyle_Design $design The design to set 
+	 */
+	public function get_product_title( $product_id ) {
 		$product = wc_get_product( $product_id );
 		$product_title = $product->get_title();
 

--- a/includes/pages/class-mystyle-design-profile-page.php
+++ b/includes/pages/class-mystyle-design-profile-page.php
@@ -390,13 +390,15 @@ class MyStyle_Design_Profile_Page {
 	}
 
 	/**
-	 * Get the product titleas the current design.
+	 * Get the product title the current design.
 	 * @param MyStyle_Design $design The design to set 
 	 */
 	public function get_product_title( $product_id ) {
+		$product_title = null;
 		$product = wc_get_product( $product_id );
-		$product_title = $product->get_title();
-
+		if ($product) {
+			$product_title = $product->get_title();
+		}
 		return $product_title;
 	}
 

--- a/includes/pages/class-mystyle-design-profile-page.php
+++ b/includes/pages/class-mystyle-design-profile-page.php
@@ -390,10 +390,10 @@ class MyStyle_Design_Profile_Page {
 	}
 
 	/**
-	 * Get the product title.
-	 * @param MyStyle_Design $design The design to set as the current design.
+	 * Get the product titleas the current design.
 	 */
-	public function get_product_title( $product_id ) {
+	public function get_product_title( $product_id ) {.
+	 * @param MyStyle_Design $design The design to set 
 		$product = wc_get_product( $product_id );
 		$product_title = $product->get_title();
 

--- a/includes/pages/class-mystyle-design-profile-page.php
+++ b/includes/pages/class-mystyle-design-profile-page.php
@@ -390,6 +390,17 @@ class MyStyle_Design_Profile_Page {
 	}
 
 	/**
+	 * Get the product title.
+	 * @param MyStyle_Design $design The design to set as the current design.
+	 */
+	public function get_product_title( $product_id ) {
+		$product = wc_get_product( $product_id );
+		$product_title = $product->get_title();
+
+		return $product_title;
+	}
+
+	/**
 	 * Sets the current design.
 	 * @param MyStyle_Design $design The design to set as the current design.
 	 */

--- a/includes/shortcodes/class-mystyle-customizer-shortcode.php
+++ b/includes/shortcodes/class-mystyle-customizer-shortcode.php
@@ -109,9 +109,9 @@ abstract class MyStyle_Customizer_Shortcode {
 		}
 
 		//TODO: skip enter email step if logged in and email can be pulled from user acct
-		//if ($CURRENT_USER) {
-		//$settings['email_skip'] = 1;
-		//}
+		if ( is_user_logged_in() ) {
+			$settings['email_skip'] = 1;
+		}
 		// base64 encode settings
 		$encoded_settings = base64_encode(json_encode($settings));
 

--- a/includes/shortcodes/class-mystyle-customizer-shortcode.php
+++ b/includes/shortcodes/class-mystyle-customizer-shortcode.php
@@ -25,6 +25,29 @@ abstract class MyStyle_Customizer_Shortcode {
 	}
 
 	/**
+	 * Modify the WooCommerce products link to only include MyStyle
+	 */
+	public static function modify_link_for_product_link() {
+		global $product;
+		$customize_page_id = MyStyle_Customize_Page::get_id();
+
+	    $product_id = $product->get_id();
+		$post_data = array(
+			'quantity' => 1,
+			'add-to-cart' => $product_id,
+		);
+
+		$passthru['post'] = $post_data;
+		$passthru_encoded = base64_encode(json_encode($passthru));
+		$customize_args = array(
+			'product_id' => $product_id,
+			'h' => $passthru_encoded,
+		);
+		$customizer_url = add_query_arg($customize_args, get_permalink($customize_page_id));
+	    echo '<a href="' . $customizer_url . '" class="woocommerce-LoopProduct-link">';
+	}
+
+	/**
 	 * Output the customizer shortcode.
 	 */
 	public static function output() {

--- a/templates/design-profile/index.php
+++ b/templates/design-profile/index.php
@@ -20,12 +20,14 @@ if (!defined('ABSPATH')) {
 			/* @var $design MyStyle_Design */
 			foreach ($pager->get_items() AS $design) {
 				$design_url = MyStyle_Design_Profile_page::get_design_url($design);
+				$product_id  = $design->get_product_id();
+				$product_title = MyStyle_Design_Profile_page::get_product_title( $product_id );
 				?>
 				<li>
 					<a href="<?php echo $design_url ?>">
 						<img src="<?php echo $design->get_thumb_url(); ?>" />
 						<span class="mystyle-design-id">
-							<?php echo ( $design->get_design_title() ?: $design->get_design_id() ); ?>
+							<?php echo 'Custom '.$product_title.' '.$design->get_design_id(); ?>
 						</span>
 					</a>
 				</li>

--- a/templates/design-profile/index.php
+++ b/templates/design-profile/index.php
@@ -25,7 +25,7 @@ if (!defined('ABSPATH')) {
 					<a href="<?php echo $design_url ?>">
 						<img src="<?php echo $design->get_thumb_url(); ?>" />
 						<span class="mystyle-design-id">
-							<?php echo $design->get_design_id(); ?>
+							<?php echo ( $design->get_design_title() ?: $design->get_design_id() ); ?>
 						</span>
 					</a>
 				</li>

--- a/templates/design-profile/index.php
+++ b/templates/design-profile/index.php
@@ -26,9 +26,10 @@ if (!defined('ABSPATH')) {
 				<li>
 					<a href="<?php echo $design_url ?>">
 						<img src="<?php echo $design->get_thumb_url(); ?>" />
-						<span class="mystyle-design-id">
-							<?php echo 'Custom '.$product_title.' '.$design->get_design_id(); ?>
-						</span>
+						<h3 class="mystyle-design-id">
+							<?php 
+							echo 'Custom '.$product_title.' <span>'.$design->get_design_id().'</span>'; ?>
+						</h3>
 					</a>
 				</li>
 				<?php

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -71,7 +71,7 @@ if (!defined('ABSPATH')) {
 	      	remove_action( 'woocommerce_before_shop_loop', 'woocommerce_catalog_ordering', 10 );
 			remove_action( 'woocommerce_before_shop_loop', 'woocommerce_result_count', 20 );
 
-			$out = do_shortcode('[products per_page="12" limit="12" paginate="true"]');
+			$out = do_shortcode('[products per_page="12" limit="12" pagination="true"]');
 
 			if (strlen($out) < 50) {
 				$out = '<p>Sorry, no products are currently available for customization.</p>';

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -51,11 +51,12 @@ if (!defined('ABSPATH')) {
 
     <div class="product_description">
     	<?php 
-			$product_id = $design->get_product_id();
-			$product = wc_get_product( $product_id ); ?>
-			<h2 class='linked_title'><?php echo $product->get_title(); ?></h2>
-			<div class='linked_desc'><?php echo ( $product->get_description() ) ?: 'No description.'; ?></div>
-    </div>
+		$product_id = $design->get_product_id();
+		$product_link = get_permalink( $product_id );
+		$product = wc_get_product( $product_id ); ?>
+		<h2 class='linked_title'><a href="<?php echo $product_link; ?>"><?php echo "Custom ".$product->get_title(); ?></a></h2>
+		<div class='linked_desc'><?php echo ( $product->get_description() ) ?: 'No description.'; ?></div>
+	</div>
 
 </div>
 

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -60,7 +60,7 @@ if (!defined('ABSPATH')) {
 			<h2 class='linked_title'><a href="<?php echo $product_link; ?>"><?php echo "Custom ".$product->get_title(); ?></a></h2>
 			<div class='linked_desc'><?php echo ( $product->get_description() ) ?: 'No description.'; ?></div>
     </div>
-    <div class="customize_products <?php echo $class; ?>">
+    <div class="customize_products <?php echo $layout_view; ?>">
     	<h2>Load design on another product:</h2>
     	<?php 
 			$mystyle_app_id = MyStyle_Options::get_api_key();

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -71,7 +71,7 @@ if (!defined('ABSPATH')) {
 	      	remove_action( 'woocommerce_before_shop_loop', 'woocommerce_catalog_ordering', 10 );
 			remove_action( 'woocommerce_before_shop_loop', 'woocommerce_result_count', 20 );
 
-			$out = do_shortcode('[products per_page="12" limit="12" pagination="true"]');
+			$out = do_shortcode('[products per_page="12" limit="12" paginate="true"]');
 
 			if (strlen($out) < 50) {
 				$out = '<p>Sorry, no products are currently available for customization.</p>';

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -56,7 +56,7 @@ if (!defined('ABSPATH')) {
 			$product_id = $design->get_product_id();
 			$product_link = get_permalink( $product_id );
 			$product = wc_get_product( $product_id ); 
-			$get_layout_views = MyStyle_Options::get_layout_views();
+			$get_layout_views = MyStyle_Options::get_layout_view();
 			if( !empty( $get_layout_views ) ){
 				$class = $get_layout_views;
 			}else{

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -48,5 +48,14 @@ if (!defined('ABSPATH')) {
             </form>
         </li>
     </ul>
+
+    <div class="product_description">
+    	<?php 
+			$product_id = $design->get_product_id();
+			$product = wc_get_product( $product_id ); ?>
+			<h2 class='linked_title'><?php echo $product->get_title(); ?></h2>
+			<div class='linked_desc'><?php echo ( $product->get_description() ) ?: 'No description.'; ?></div>
+    </div>
+
 </div>
 

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -27,11 +27,10 @@ if (!defined('ABSPATH')) {
     </ul>
     <img id="mystyle-design-profile-img" src="<?php echo $design->get_web_url(); ?>"/>
     <ul class="mystyle-button-group">
-        <li><a onclick="location.href = '<?php echo $design->get_reload_url(); ?>';" class="button">Customize</a></li>
         <li>
             <form enctype="multipart/form-data" method="post" action="<?php echo get_permalink($design->get_product_id()); ?>">
 				<?php
-//if we have the cart_data (older versions of the plugin don't) through it all into hidden fields
+				//if we have the cart_data (older versions of the plugin don't) through it all into hidden fields
 				if ($design->get_cart_data_array() != null) {
 					foreach ($design->get_cart_data_array() AS $key => $value) {
 						echo '<input type="hidden" name="' . $key . '" value="' . sanitize_title($value) . '" />';
@@ -47,16 +46,43 @@ if (!defined('ABSPATH')) {
 					<?php } ?>
             </form>
         </li>
+        <li><a href="<?php echo $design->get_reload_url(); ?>" class="button">Customize</a></li>
+        <li><a href="<?php echo $design->get_scratch_url(); ?>" class="button">Design from scratch</a></li>
+
     </ul>
 
     <div class="product_description">
     	<?php 
-		$product_id = $design->get_product_id();
-		$product_link = get_permalink( $product_id );
-		$product = wc_get_product( $product_id ); ?>
-		<h2 class='linked_title'><a href="<?php echo $product_link; ?>"><?php echo "Custom ".$product->get_title(); ?></a></h2>
-		<div class='linked_desc'><?php echo ( $product->get_description() ) ?: 'No description.'; ?></div>
-	</div>
+			$product_id = $design->get_product_id();
+			$product_link = get_permalink( $product_id );
+			$product = wc_get_product( $product_id ); 
+			$get_layout_views = MyStyle_Options::get_layout_views();
+			if( !empty( $get_layout_views ) ){
+				$class = $get_layout_views;
+			}else{
+				$class = '';
+			}
+		?>
+			<h2 class='linked_title'><a href="<?php echo $product_link; ?>"><?php echo "Custom ".$product->get_title(); ?></a></h2>
+			<div class='linked_desc'><?php echo ( $product->get_description() ) ?: 'No description.'; ?></div>
+    </div>
+    <div class="customize_products <?php echo $class; ?>">
+    	<h2>Load design on another product:</h2>
+    	<?php 
+			$mystyle_app_id = MyStyle_Options::get_api_key();
+			$out = '';
+			add_filter('woocommerce_shortcode_products_query', array('MyStyle_Customizer_Shortcode', 'modify_woocommerce_shortcode_products_query'), 10, 1);
+	      	remove_action( 'woocommerce_after_shop_loop',  'woocommerce_catalog_ordering', 10 );
+	      	remove_action( 'woocommerce_after_shop_loop',  'woocommerce_result_count', 20 );
+	      	remove_action( 'woocommerce_before_shop_loop', 'woocommerce_catalog_ordering', 10 );
+			remove_action( 'woocommerce_before_shop_loop', 'woocommerce_result_count', 20 );
 
+			$out = do_shortcode('[products per_page="12" limit="12" paginate="true"]');
+
+			if (strlen($out) < 50) {
+				$out = '<p>Sorry, no products are currently available for customization.</p>';
+			}
+			echo $out;
+    	?>
+    </div>
 </div>
-

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -60,23 +60,25 @@ if (!defined('ABSPATH')) {
 			<h2 class='linked_title'><a href="<?php echo $product_link; ?>"><?php echo "Custom ".$product->get_title(); ?></a></h2>
 			<div class='linked_desc'><?php echo ( $product->get_description() ) ?: 'No description.'; ?></div>
     </div>
-    <div class="customize_products <?php echo $layout_view; ?>">
-    	<h2>Load design on another product:</h2>
-    	<?php 
-			$mystyle_app_id = MyStyle_Options::get_api_key();
-			$out = '';
-			add_filter('woocommerce_shortcode_products_query', array('MyStyle_Customizer_Shortcode', 'modify_woocommerce_shortcode_products_query'), 10, 1);
-	      	remove_action( 'woocommerce_after_shop_loop',  'woocommerce_catalog_ordering', 10 );
-	      	remove_action( 'woocommerce_after_shop_loop',  'woocommerce_result_count', 20 );
-	      	remove_action( 'woocommerce_before_shop_loop', 'woocommerce_catalog_ordering', 10 );
-			remove_action( 'woocommerce_before_shop_loop', 'woocommerce_result_count', 20 );
+    <?php if ($layout_view != 'disabled') { ?>
+		    <div class="customize_products <?php echo $layout_view; ?>">
+		    	<h2>Load design on another product:</h2>
+		    	<?php 
+					$mystyle_app_id = MyStyle_Options::get_api_key();
+					$out = '';
+					add_filter('woocommerce_shortcode_products_query', array('MyStyle_Customizer_Shortcode', 'modify_woocommerce_shortcode_products_query'), 10, 1);
+			      	remove_action( 'woocommerce_after_shop_loop',  'woocommerce_catalog_ordering', 10 );
+			      	remove_action( 'woocommerce_after_shop_loop',  'woocommerce_result_count', 20 );
+			      	remove_action( 'woocommerce_before_shop_loop', 'woocommerce_catalog_ordering', 10 );
+					remove_action( 'woocommerce_before_shop_loop', 'woocommerce_result_count', 20 );
 
-			$out = do_shortcode('[products per_page="12" limit="12" paginate="true"]');
+					$out = do_shortcode('[products]');
 
-			if (strlen($out) < 50) {
-				$out = '<p>Sorry, no products are currently available for customization.</p>';
-			}
-			echo $out;
+					if (strlen($out) < 50) {
+						$out = '<p>Sorry, no products are currently available for customization.</p>';
+					}
+				echo $out;
+		    }
     	?>
     </div>
 </div>

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -66,6 +66,9 @@ if (!defined('ABSPATH')) {
 		    	<?php 
 					$mystyle_app_id = MyStyle_Options::get_api_key();
 					$out = '';
+					remove_action( 'woocommerce_before_shop_loop_item', 'woocommerce_template_loop_product_link_open', 10 );
+        			add_action( 'woocommerce_before_shop_loop_item', array('MyStyle_Customizer_Shortcode', 'modify_link_for_product_link'), 10, 1);
+
 					add_filter('woocommerce_shortcode_products_query', array('MyStyle_Customizer_Shortcode', 'modify_woocommerce_shortcode_products_query'), 10, 1);
 			      	remove_action( 'woocommerce_after_shop_loop',  'woocommerce_catalog_ordering', 10 );
 			      	remove_action( 'woocommerce_after_shop_loop',  'woocommerce_result_count', 20 );

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -56,13 +56,7 @@ if (!defined('ABSPATH')) {
 			$product_id = $design->get_product_id();
 			$product_link = get_permalink( $product_id );
 			$product = wc_get_product( $product_id ); 
-			$get_layout_views = MyStyle_Options::get_layout_view();
-			if( !empty( $get_layout_views ) ){
-				$class = $get_layout_views;
-			}else{
-				$class = '';
-			}
-		?>
+			$layout_view = MyStyle_Options::get_layout_view(); ?>
 			<h2 class='linked_title'><a href="<?php echo $product_link; ?>"><?php echo "Custom ".$product->get_title(); ?></a></h2>
 			<div class='linked_desc'><?php echo ( $product->get_description() ) ?: 'No description.'; ?></div>
     </div>


### PR DESCRIPTION
- Add product titles to /designs/ page tiles with "custom " prefix
- Add transpose menu (products to load design onto) on design profile page (links to customizer with design id and product id)
- add "email_skip=1" for customizer iframe url data to skip email entry if you're logged in
- add global mystyle setting for transpose menu to be in a text list (list) or as product titles (grid) view