### PR TITLE
Admin Style Tweaks

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -204,3 +204,22 @@ span#mystyle-icon-general.icon100 {
 .mystyle-admin-box.warning {
 	border-top-color: #ffb900;
 }
+
+/**
+woocommerce order mystyle data area
+*/
+.woocommerce_order_items .mystyle-panel a.button {
+    display: block;
+    text-align: center;
+    max-width: 190px;
+    margin: 8px auto;
+}
+
+.woocommerce_order_items .mystyle-panel img {
+    margin: auto;
+    display: block;
+}
+
+a.mystyle-toggle-link.button {
+	min-width: 100px;
+}

--- a/includes/admin/class-mystyle-woocommerce-admin-order.php
+++ b/includes/admin/class-mystyle-woocommerce-admin-order.php
@@ -75,7 +75,7 @@ class MyStyle_WooCommerce_Admin_Order {
 		<td class="item-mystyle">
 			<?php if ( null !== $design ) : ?>
 				<div class="mystyle-toggle" onclick="mystyleTogglePanelVis(<?php echo $item_id; ?>)">
-					<a class="mystyle-toggle-link" title="Click to toggle">MyStyle Data</a>
+					<a class="mystyle-toggle-link button" title="Click to toggle">MyStyle Data</a>
 					<a id="mystyle-toggle-handle-<?php echo $item_id; ?>" class="mystyle-toggle-handle" title="Click to toggle" onclick="mystyleTogglePanelVis(<?php echo $item_id; ?>)"></a>
 				</div>
 				<div class="mystyle-panel" id="mystyle-panel-<?php echo $item_id; ?>" style="display:none;">


### PR DESCRIPTION
Admin Mystyle Data toggle button instead of link and child menu button sizes larger for cleaner UI, better visibility / usability

### All Submissions:

* [x] Have you followed the [MyStyle Contributing guideline](https://github.com/mystyle-platform/mystyle-wp-custom-product-designer/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. check the admin orders and click the toggle button for mystyle data
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
