### PR TITLE
Viewport JS Bugfix Patch

### DIFF
--- a/assets/js/customize.js
+++ b/assets/js/customize.js
@@ -127,8 +127,12 @@ MyStyleCustomize = ( function() {
 
 		console.log( 'MyStyle customize page setting viewport: (' + orientation + ') final scale: ' + finalScale + ' ( orig: ' + scale + ') screen width: ' + screenWidthPx );
 
+		var hasViewport = typeof currentViewportTag$ !== 'undefined' 
+						&& currentViewportTag$ 
+						&& (0 < currentViewportTag$.length > 0);
+		
 		// Set the viewport.
-		if ( 0 < currentViewportTag$.size() ) {
+		if ( hasViewport ) {
 			jQuery( 'meta[name="viewport"]' ).remove(); // Removal (remove and re-add seems to trigger viewport update better).
 		}
 		jQuery( 'head' ).append( newViewportTagHTML ); // Add new.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 = 3.12.4 =
 
-* Fixed a bug where deleted designs where breaking the cart (if the user had 
-  that particular design in their cart).
+* Fixed a bug where deleted designs were breaking the cart (if the user had that
+  particular design in their cart).
 * Updated the readme.txt to reflect that the plugin has been tested with up to WP 5.2.2.
 
 = 3.12.3 =

--- a/readme.txt
+++ b/readme.txt
@@ -82,8 +82,8 @@ The MyStyle Custom Product Designer requires that you have WordPress with the Wo
 == Changelog ==
 
 = 3.12.4 =
-* Fixed a bug where deleted designs where breaking the cart (if the user had 
-  that particular design in their cart).
+* Fixed a bug where deleted designs were breaking the cart (if the user had that
+  particular design in their cart).
 * Updated the readme.txt to reflect that the plugin has been tested with up to WP 5.2.2.
 
 = 3.12.3 =


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MyStyle Contributing guideline](https://github.com/mystyle-platform/mystyle-wp-custom-product-designer/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Bugfix for .size() -> .length in jQuery javascript

Closes # .

### How to test the changes in this Pull Request:

1. customizer page errors in console should go away
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Customizer page bugfix for viewport code.
