### PR TITLE
Only Create the MyStyle Session When Necessary

### DIFF
--- a/includes/class-mystyle-sessionhandler.php
+++ b/includes/class-mystyle-sessionhandler.php
@@ -39,7 +39,6 @@ class MyStyle_SessionHandler {
 	public function __construct() {
 		$this->use_cookies = true; // Use cookie by default.
 
-		add_action( 'init', array( &$this, 'start_session' ), 1, 0 );
 		add_action( 'wp_logout', array( &$this, 'end_session' ), 10, 0 );
 		add_action( 'wp_login', array( &$this, 'start_session' ), 10, 0 );
 	}

--- a/includes/frontend/class-mystyle-frontend.php
+++ b/includes/frontend/class-mystyle-frontend.php
@@ -119,14 +119,13 @@ class MyStyle_FrontEnd {
 	 */
 	public function init_vars() {
 
-		$this->user = wp_get_current_user();
-
-		$this->session = MyStyle()->get_session();
-
 		// Get the design from the url.
 		$design_id = MyStyle_Util::get_query_var_int( 'design_id' );
 
 		if ( null !== $design_id ) {
+			$this->user = wp_get_current_user();
+			$this->session = MyStyle()->get_session();
+
 			// Get the design. If the user doesn't have access, an exception
 			// is thrown.
 			try {
@@ -179,17 +178,17 @@ class MyStyle_FrontEnd {
 		// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 		echo $form_integration_config;
 	}
-    
+
     /**
      * Add body class for MyStyle customizable products
      */
     public function filter_body_class( $classes ) {
-        
+
         if( is_product() ) {
             $product = wc_get_product() ;
-            
+
             if ( !$product->is_in_stock() ) {
-                $classes[] = 'mystyle-product-not-in-stock' ;    
+                $classes[] = 'mystyle-product-not-in-stock' ;
             }
         }
 

--- a/includes/shortcodes/class-mystyle-design-collection-shortcode.php
+++ b/includes/shortcodes/class-mystyle-design-collection-shortcode.php
@@ -42,7 +42,8 @@ abstract class MyStyle_Design_Collection_Shortcode {
         
 		$wp_user = wp_get_current_user();
 
-		$session = MyStyle()->get_session();
+		//$session = MyStyle()->get_session();
+		$session = null; // No longer using sessions for design-collection shortcode.
         
         $show_designs           = true ;
         $collections_per_page   = 24 ;

--- a/includes/shortcodes/class-mystyle-design-tag-shortcode.php
+++ b/includes/shortcodes/class-mystyle-design-tag-shortcode.php
@@ -37,7 +37,8 @@ abstract class MyStyle_Design_Tag_Shortcode {
         
 		$wp_user = wp_get_current_user();
 
-		$session = MyStyle()->get_session();
+		//$session = MyStyle()->get_session();
+		$session = null; // No longer using sessions for design-tag shortcode.
         
         $show_designs           = true ;
         $tags_per_page          = 24 ;


### PR DESCRIPTION
Now only creating the session when necessary. Removed/modified code that was creating the session on all pages).

### All Submissions:

* [X] Have you followed the [MyStyle Contributing guideline](https://github.com/mystyle-platform/mystyle-wp-custom-product-designer/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Updated the code to only create a MyStyle session when a MyStyle session is specifically needed. Removed code that was creating sessions on every page of the site. This fixes and issue where the mystyle cookie was preventing page level caching.

### Changelog entry

Updated the code to only create a MyStyle session when a MyStyle session is specifically needed. Removed code that was creating sessions on every page of the site. This fixes and issue where the mystyle cookie was preventing page level caching.
