### PR TITLE
Web size thumbnails for design tiles, Title box UI hidden on design profiles

### DIFF
--- a/templates/design-collection-index.php
+++ b/templates/design-collection-index.php
@@ -29,7 +29,7 @@
                 <div class="design-img">
                     
                     <a href="<?php echo esc_url( $design_url ); ?>" title="<?php echo esc_attr( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?>">
-                        <img alt="<?php echo esc_html( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?> Image" src="<?php echo esc_url( $design->get_thumb_url() ); ?>" />
+                        <img alt="<?php echo esc_html( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?> Image" src="<?php echo esc_url( $design->get_web_url() ); ?>" />
                         <?php echo esc_html( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?>
                     </a>
                     <?php if( $user ) : ?>

--- a/templates/design-profile/index.php
+++ b/templates/design-profile/index.php
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				?>
 				<li>
 					<a href="<?php echo esc_attr( $design_url ); ?>">
-						<img src="<?php echo esc_attr( $design->get_thumb_url() ); ?>" />
+						<img src="<?php echo esc_attr( $design->get_web_url() ); ?>" />
 						<h3 class="mystyle-design-id">
 							<?php
 							if ( ! empty( $design->get_title() ) ) {

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div id="mystyle-design-profile-wrapper" class="woocommerce">
 	<?php if ( ( ( 0 !== $design->get_user_id() ) && ( get_current_user_id() === $design->get_user_id() ) ) || ( current_user_can( 'administrator' ) ) ) : ?>
-	<a id="ms-edit-title-form-show" href="#">Edit Title</a>
+	<a id="ms-edit-title-form-show" href="#" style="display:none;">Edit Title</a>
 	<div id="ms-edit-title-form">
 		<form method="post" id="ms-edit-title-form">
 			<input type="text" name="ms_title" value="<?php echo ( ( ! empty( $design->get_title() ) ) ? esc_attr( $design->get_title() ) : ( 'Design ' . esc_attr( $design->get_design_id() ) ) ); ?>" />


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [MyStyle Contributing guideline](https://github.com/mystyle-platform/mystyle-wp-custom-product-designer/blob/master/.github/CONTRIBUTING.md)?
* [X ] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Thumbs to web size images for recent designs and design collections

### How to test the changes in this Pull Request:

1.  Check the website /designs/ page is using web URLs
2.  Check the website /design-collections/ page is using web URLs
3.  Check the website design profile page for any design does not show a title edit box while loading on screen

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

- Design thumbs changed to Web size URLs
- Edit title box hidden with in-line style for hiding during page load 
