### PR TITLE
Display single collection via shortcode

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -146,8 +146,10 @@
                                 'action': 'mystyle_design_tag_search',
                                 'tax': 'design_tag',
                                 'q': request.term
-                            }, function( data ) {
-                                response( data.data );
+                            }, function (data) {
+                                // Decode HTML entities before responding
+                                const decodedData = data.data.map(item => $("<textarea/>").html(item).text());
+                                response(decodedData);
                             });
                         },
                         delay: 100
@@ -213,8 +215,10 @@
                                 'action': 'mystyle_design_collection_search',
                                 'tax': 'design_collection',
                                 'q': request.term
-                            }, function( data ) {
-                                response( data.data );
+                            }, function (data) {
+                                // Decode HTML entities before responding
+                                const decodedData = data.data.map(item => $("<textarea/>").html(item).text());
+                                response(decodedData);
                             });
                         },
                         delay: 100

--- a/includes/shortcodes/class-mystyle-design-shortcode.php
+++ b/includes/shortcodes/class-mystyle-design-shortcode.php
@@ -134,9 +134,12 @@ abstract class MyStyle_Design_Shortcode {
 			$tag = $atts['tag'];
 
 			$out = self::output_tagged_designs( $tag, $count );
+		} elseif (isset($atts['collection'])) { // If collection is passed, serve designs with the specified collection.
+			$collection = $atts['collection'];
+			$out = self::output_collection_designs($collection, $count);
 		} else {
 			// Serve random designs.
-			$out = self::output_random_designs( $count );
+			$out = self::output_random_designs($count);
 		}
 
 		return $out;
@@ -216,4 +219,44 @@ abstract class MyStyle_Design_Shortcode {
 		return $out;
 	}
 
+
+
+	/**
+	 * Private helper method that returns the output for the gallery of designs
+	 * for a specific collections.
+	 */
+
+
+	private static function output_collection_designs($collection, $count)
+	{
+
+		$term = get_term_by('name', $collection, 'design_collection');
+
+		$term_taxonomy_id = $term->term_taxonomy_id;
+
+		$user = wp_get_current_user();
+
+		$session = MyStyle()->get_session();
+
+		// Create a new pager.
+		$pager = new MyStyle_Pager();
+
+		// Designs per page.
+		$pager->set_items_per_page($count);
+
+		$pager->set_current_page_number(1);
+
+		// Pager items.
+		$designs = MyStyle_DesignManager::get_designs_by_term_id($term_taxonomy_id, $user, $session, $count, 1);
+
+		$pager->set_items($designs);
+
+		// ---------- Call the view layer ------------------ //
+		ob_start();
+		require MYSTYLE_TEMPLATES . 'design-profile/index.php';
+		$out = ob_get_contents();
+		ob_end_clean();
+
+		return $out;
+	}
 }

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -14,8 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div id="mystyle-design-profile-wrapper" class="woocommerce">
 	<?php if ( ( ( 0 !== $design->get_user_id() ) && ( get_current_user_id() === $design->get_user_id() ) ) || ( current_user_can( 'administrator' ) ) ) : ?>
-	<a id="ms-edit-title-form-show" href="#" style="display:none;">Edit Title</a>
-	<div id="ms-edit-title-form">
+	<a id="ms-edit-title-form-show" href="#">Edit Title</a>
+	<div id="ms-edit-title-form" style="display:none;">
 		<form method="post" id="ms-edit-title-form">
 			<input type="text" name="ms_title" value="<?php echo ( ( ! empty( $design->get_title() ) ) ? esc_attr( $design->get_title() ) : ( 'Design ' . esc_attr( $design->get_design_id() ) ) ); ?>" />
 			<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( 'mystyle_design_edit_nonce' ) ); ?>" />

--- a/templates/design-tag-index.php
+++ b/templates/design-tag-index.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The template for displaying the MyStyle design tag index.
  *
@@ -8,62 +9,62 @@
  * @since 3.17.5
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly.
 }
 ?>
 
-<div id="mystyle-design-tag-index-wrapper" class="mystyle-design-tag-index woocommerce design-tags<?php print ( $show_designs ? ' show-designs' : '' ) ; ?>">
-    <?php if( ! $term ) : ?>    
-    <div class="mystyle-sort">
-        <form name="mystyle-sort-form" method="get" class="mystyle-sort-form" action="<?php print get_permalink( get_the_ID() ); ?>">
-            <label for="mystyle-sort-select">Sort tags by:</label>
-            <select name="sort_by" class="mystyle-sort-select">
-                <option value="qty"<?php print ($sort_by == 'qty' ? ' selected' : '' ) ; ?>>Quantity</option>
-                <option value="alpha"<?php print ($sort_by == 'alpha' ? ' selected' : '' ) ; ?>>Alphabetical</option>
-            </select>
-        </form>
-    </div>
-    <?php endif ; ?>
-	<?php foreach ( $terms as $term ) : ?>
-    <?php if($show_designs) : ?>
-    <?php $term_name = preg_replace('/\-/', ' ', $term->name ) ; ?>
-	<h3 class="mystyle-tag-id"><a href="<?php echo esc_url( get_term_link( $term ) ); ?>" title="<?php echo esc_attr( $term_name ); ?> Gallery"><?php echo esc_html( $term_name ); ?></a></h3>
-	<ul>
-		<?php foreach ( $term->designs as $design ) : ?>
-			<?php
-			$design_url = MyStyle_Design_Profile_page::get_design_url( $design );
-			$user       = get_user_by( 'id', $design->get_user_id() );
-			?>
-		<li>
-			<a href="<?php echo esc_url( $design_url ); ?>" title="<?php echo esc_attr( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?>">
-				<img alt="<?php echo esc_html( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?> Image" src="<?php echo esc_url( $design->get_thumb_url() ); ?>" />
-				<?php echo esc_html( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?>
-			</a>
-			<div class="mystyle-design-author">Designed by: <?php echo esc_html( $user->user_nicename ); ?></div>
-		</li>
-		<?php endforeach; ?>
-	</ul>
-    <?php else : ?>
-    <a href="<?php echo esc_url( get_term_link( $term ) ); ?>" title="<?php echo esc_attr( $term->name ); ?> Gallery"><?php echo esc_html( $term->name ); ?></a>
-    <?php endif ; ?>&nbsp;
-	<?php endforeach; ?>
-    <nav class="woocommerce-pagination">
-        <?php
-        echo paginate_links( // WPCS: XSS ok.
-            array(
-                'base'      => esc_url_raw( str_replace( 999999999, '%#%', get_pagenum_link( 999999999, false ) ) ),
-                'format'    => '',
-                'add_args'  => false,
-                'current'   => $mystyle_pager->get_current_page_number(),
-                'total'     => $mystyle_pager->get_page_count(),
-                'prev_text' => '&larr;',
-                'next_text' => '&rarr;',
-                'type'      => 'list',
-                'end_size'  => 3,
-                'mid_size'  => 3,
-            )
-        );
-        ?>
-    </nav>
+<div id="mystyle-design-tag-index-wrapper" class="mystyle-design-tag-index woocommerce design-tags<?php print($show_designs ? ' show-designs' : ''); ?>">
+    <?php if (!$term) : ?>
+        <div class="mystyle-sort">
+            <form name="mystyle-sort-form" method="get" class="mystyle-sort-form" action="<?php print get_permalink(get_the_ID()); ?>">
+                <label for="mystyle-sort-select">Sort tags by:</label>
+                <select name="sort_by" class="mystyle-sort-select">
+                    <option value="qty" <?php print($sort_by == 'qty' ? ' selected' : ''); ?>>Quantity</option>
+                    <option value="alpha" <?php print($sort_by == 'alpha' ? ' selected' : ''); ?>>Alphabetical</option>
+                </select>
+            </form>
+        </div>
+    <?php endif; ?>
+    <?php foreach ($terms as $term) : ?>
+        <?php if ($show_designs) : ?>
+            <?php $term_name = preg_replace('/\-/', ' ', $term->name); ?>
+            <h3 class="mystyle-tag-id"><a href="<?php echo esc_url(get_term_link($term)); ?>" title="<?php echo esc_attr($term_name); ?> Gallery"><?php echo esc_html($term_name); ?></a></h3>
+            <ul>
+                <?php foreach ($term->designs as $design) : ?>
+                    <?php
+                    $design_url = MyStyle_Design_Profile_page::get_design_url($design);
+                    $user       = get_user_by('id', $design->get_user_id());
+                    ?>
+                    <li>
+                        <a href="<?php echo esc_url($design_url); ?>" title="<?php echo esc_attr((null !== $design->get_title()) ? $design->get_title() : 'Custom Design ' . $design->get_design_id()); ?>">
+                            <img alt="<?php echo esc_html((null !== $design->get_title()) ? $design->get_title() : 'Custom Design ' . $design->get_design_id()); ?> Image" src="<?php echo esc_url($design->get_web_url()); ?>" />
+                            <?php echo esc_html((null !== $design->get_title()) ? $design->get_title() : 'Custom Design ' . $design->get_design_id()); ?>
+                        </a>
+                        <div class="mystyle-design-author">Designed by: <?php echo esc_html($user->user_nicename); ?></div>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php else : ?>
+            <a href="<?php echo esc_url(get_term_link($term)); ?>" title="<?php echo esc_attr($term->name); ?> Gallery"><?php echo esc_html($term->name); ?></a>
+            <?php endif; ?>&nbsp;
+        <?php endforeach; ?>
+        <nav class="woocommerce-pagination">
+            <?php
+            echo paginate_links( // WPCS: XSS ok.
+                array(
+                    'base'      => esc_url_raw(str_replace(999999999, '%#%', get_pagenum_link(999999999, false))),
+                    'format'    => '',
+                    'add_args'  => false,
+                    'current'   => $mystyle_pager->get_current_page_number(),
+                    'total'     => $mystyle_pager->get_page_count(),
+                    'prev_text' => '&larr;',
+                    'next_text' => '&rarr;',
+                    'type'      => 'list',
+                    'end_size'  => 3,
+                    'mid_size'  => 3,
+                )
+            );
+            ?>
+        </nav>
 </div>


### PR DESCRIPTION
Added support like "collection" for a single-collection display shortcode.

### All Submissions:

* [x] Have you followed the [MyStyle Contributing guideline](https://github.com/mystyle-platform/mystyle-wp-custom-product-designer/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Add support for a single-collection display shortcode.

### How to test the changes in this Pull Request:

1. Use a shortcode [mystyle_design collection="<collection_name>"]

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add support for a single-collection display shortcode.

