### PR TITLE
For non-valid license holders, where detected, switch back to _thumb_

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -171,16 +171,16 @@ register_activation_hook(__FILE__, 'myplugin_activate');
 add_action('wp', 'schedule_daily_cron');
 function schedule_daily_cron()
 {
-	if (!wp_next_scheduled('update_credentials_status')) {
+	if ( ! wp_next_scheduled('mystyle_update_credentials_status')) {
 		// Set the cron job to run every day at 3:00 AM (adjust the time if needed)
 		$timestamp = strtotime('3:00 AM');
-		wp_schedule_event($timestamp, 'daily', 'update_credentials_status');
+		wp_schedule_event($timestamp, 'daily', 'mystyle_update_credentials_status');
 	}
 }
 
 
 // Hook for the scheduled cron job
-add_action('update_credentials_status', 'update_credentials_status_callback');
+add_action('mystyle_update_credentials_status', 'update_credentials_status_callback');
 function update_credentials_status_callback()
 {
 	$stored_license_status = get_option('mystyle_license_status_');

--- a/includes/admin/pages/class-mystyle-options-page.php
+++ b/includes/admin/pages/class-mystyle-options-page.php
@@ -165,6 +165,23 @@ class MyStyle_Options_Page {
 			'mystyle_options',
 			'mystyle_options_advanced_section'
 		);
+		
+		
+		/* DESIGN IMAGE  */
+	add_settings_section(
+		'mystyle_options_image_section',
+		'Image Settings',
+		array(&$this, 'render_image_section_text'),
+		'mystyle_options'
+	);
+
+	add_settings_field(
+		'image_type',
+		'Image Type',
+		array(&$this, 'render_image_type'),
+		'mystyle_options',
+		'mystyle_options_image_section'
+	);
 	}
 
 	/**
@@ -488,6 +505,24 @@ class MyStyle_Options_Page {
 		<?php
 	}
 
+
+			// Function to render image size settings
+			public function render_image_section_text()
+			{
+				echo '<p>Select the type of image to render.</p>';
+			}
+
+			public function render_image_type()
+			{
+				$options = get_option(MYSTYLE_OPTIONS_NAME, array());
+				$imageType = (array_key_exists('image_type', $options)) ? $options['image_type'] : '';
+
+				echo '<label><input type="radio" name="mystyle_options[image_type]" value="thumbnail" ' . checked('thumbnail', $imageType, false) . ' /> Thumbnail Image</label><br>';
+				echo '<label><input type="radio" name="mystyle_options[image_type]" value="web" ' . checked('web', $imageType, false) . ' /> Web Image</label>';
+			}
+
+
+
 	/**
 	 * Function to render the design_profile_product_menu_type field.
 	 */
@@ -612,6 +647,9 @@ class MyStyle_Options_Page {
 			$msg_message = 'Invalid Enable Alternate Design Complete Redirect option';
 			$new_options['enable_alternate_design_complete_redirect'] = 0;
 		}
+			
+		// Design image type thumb/web
+		$new_options['image_type'] = isset($input['image_type']) && in_array($input['image_type'], array('thumbnail', 'web')) ? $input['image_type'] : 'thumbnail';
 
 		// Design Profile Page product menu type.
 		$new_options['design_profile_product_menu_type'] = trim( $input['design_profile_product_menu_type'] );

--- a/includes/admin/pages/class-mystyle-options-page.php
+++ b/includes/admin/pages/class-mystyle-options-page.php
@@ -509,13 +509,13 @@ class MyStyle_Options_Page {
 			// Function to render image size settings
 			public function render_image_section_text()
 			{
-				echo '<p>Select the type of image to render.</p>';
+				echo '<p>Select the size of images to display in galleries.</p>';
 			}
 
 			public function render_image_type()
 			{
 				$options = get_option(MYSTYLE_OPTIONS_NAME, array());
-				$imageType = (array_key_exists('image_type', $options)) ? $options['image_type'] : '';
+				$imageType = (array_key_exists('image_type', $options)) ? $options['image_type'] : 'web';
 
 				echo '<label><input type="radio" name="mystyle_options[image_type]" value="thumbnail" ' . checked('thumbnail', $imageType, false) . ' /> Thumbnail Image</label><br>';
 				echo '<label><input type="radio" name="mystyle_options[image_type]" value="web" ' . checked('web', $imageType, false) . ' /> Web Image</label>';

--- a/includes/entities/class-mystyle-design.php
+++ b/includes/entities/class-mystyle-design.php
@@ -562,14 +562,14 @@ class MyStyle_Design implements MyStyle_Entity {
 	public function getImageUrl()
 	{
 		$license_status = get_option('mystyle_license_status_');
+		$options = get_option(MYSTYLE_OPTIONS_NAME, array());
+		$image_type = (array_key_exists('image_type', $options)) ? $options['image_type'] : 'thumbnail';
 
-		// Check if the license status is invalid
-		if ($license_status === 'invalid') {
-			$image_url = $this->get_thumb_url(); // Use thumbnail URL if license is invalid
+		if ($image_type === 'web' && $license_status == "valid") {
+			$image_url = $this->get_web_url();
 		} else {
-			$image_url = $this->get_web_url(); // Use web URL if license is valid
+			$image_url = $this->get_thumb_url();
 		}
-
 		return $image_url;
 	}
 

--- a/includes/entities/class-mystyle-design.php
+++ b/includes/entities/class-mystyle-design.php
@@ -552,6 +552,27 @@ class MyStyle_Design implements MyStyle_Entity {
 		$this->template_id = $template_id;
 	}
 
+
+
+
+	/**
+	 * Gets the value of image_url.
+	 * using license status.
+	 */
+	public function getImageUrl()
+	{
+		$license_status = get_option('mystyle_license_status_');
+
+		// Check if the license status is invalid
+		if ($license_status === 'invalid') {
+			$image_url = $this->get_thumb_url(); // Use thumbnail URL if license is invalid
+		} else {
+			$image_url = $this->get_web_url(); // Use web URL if license is valid
+		}
+
+		return $image_url;
+	}
+
 	/**
 	 * Gets the value of template_id.
 	 *
@@ -1051,5 +1072,4 @@ class MyStyle_Design implements MyStyle_Entity {
 
 		return $arr;
 	}
-
 }

--- a/includes/pages/class-mystyle-author-designs-page.php
+++ b/includes/pages/class-mystyle-author-designs-page.php
@@ -293,7 +293,7 @@ class MyStyle_Author_Designs_Page {
 		$session = MyStyle()->get_session();
 		try {
 			$design   = MyStyle_DesignManager::get( $post->design_id, $wp_user, $session );
-			$image[0] = $design->get_web_url();
+			$image[0] = $design->getImageUrl();
 			$image[1] = 200;
 			$image[2] = 200;
 		} catch ( MyStyle_Unauthorized_Exception $ex ) {
@@ -432,5 +432,4 @@ class MyStyle_Author_Designs_Page {
 
 		return self::$instance;
 	}
-
 }

--- a/includes/pages/class-mystyle-design-tag-page.php
+++ b/includes/pages/class-mystyle-design-tag-page.php
@@ -437,7 +437,7 @@ class MyStyle_Design_Tag_Page {
 			$design = MyStyle_DesignManager::get( $post->design_id, $wp_user, $session );
             
             if ( null !== $design ) {
-				$image[0] = $design->get_web_url();
+				$image[0] = $design->getImageUrl();
 				$image[1] = 200;
 				$image[2] = 200;
 			}

--- a/templates/design-collection-index.php
+++ b/templates/design-collection-index.php
@@ -29,7 +29,7 @@
                 <div class="design-img">
                     
                     <a href="<?php echo esc_url( $design_url ); ?>" title="<?php echo esc_attr( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?>">
-                        <img alt="<?php echo esc_html( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?> Image" src="<?php echo esc_url( $design->get_web_url() ); ?>" />
+                        <img alt="<?php echo esc_html( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?> Image" src="<?php echo esc_url( $design->getImageUrl() ); ?>" />
                         <?php echo esc_html( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?>
                     </a>
                     <?php if( $user ) : ?>

--- a/templates/design-collection-index.php
+++ b/templates/design-collection-index.php
@@ -30,7 +30,7 @@
                     
                     <a href="<?php echo esc_url( $design_url ); ?>" title="<?php echo esc_attr( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?>">
                         <img alt="<?php echo esc_html( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?> Image" src="<?php echo esc_url( $design->getImageUrl() ); ?>" />
-                        <?php echo esc_html( ( null !== $design->get_title() ) ? $design->get_title() : 'Custom Design ' . $design->get_design_id() ); ?>
+                     <?php echo esc_html(html_entity_decode((null !== $design->get_title()) ? $design->get_title() : 'Custom Design ' . $design->get_design_id())); ?>
                     </a>
                     <?php if( $user ) : ?>
                     <div class="mystyle-design-author">Designed by: <?php echo esc_html( $user->user_nicename ); ?></div>

--- a/templates/design-profile/index.php
+++ b/templates/design-profile/index.php
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				?>
 				<li>
 					<a href="<?php echo esc_attr( $design_url ); ?>">
-						<img src="<?php echo esc_attr( $design->get_web_url() ); ?>" />
+						<img src="<?php echo esc_attr( $design->getImageUrl() ); ?>" />
 						<h3 class="mystyle-design-id">
 							<?php
 							if ( ! empty( $design->get_title() ) ) {

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<li>&nbsp;</li>
 		<?php } ?>
 	</ul>
-	<img id="mystyle-design-profile-img" class="skip-lazy" src="<?php echo esc_attr( $design->get_web_url() ); ?>"/>
+	<img id="mystyle-design-profile-img" class="skip-lazy" src="<?php echo esc_attr( $design->getImageUrl() ); ?>"/>
 	<ul class="mystyle-button-group">
 		<li>
 			<form enctype="multipart/form-data" method="post" action="<?php echo esc_attr( get_permalink( $design->get_product_id() ) ); ?>">

--- a/templates/design-tag-index.php
+++ b/templates/design-tag-index.php
@@ -38,7 +38,7 @@ if (!defined('ABSPATH')) {
                     ?>
                     <li>
                         <a href="<?php echo esc_url($design_url); ?>" title="<?php echo esc_attr((null !== $design->get_title()) ? $design->get_title() : 'Custom Design ' . $design->get_design_id()); ?>">
-                            <img alt="<?php echo esc_html((null !== $design->get_title()) ? $design->get_title() : 'Custom Design ' . $design->get_design_id()); ?> Image" src="<?php echo esc_url($design->get_web_url()); ?>" />
+                            <img alt="<?php echo esc_html((null !== $design->get_title()) ? $design->get_title() : 'Custom Design ' . $design->get_design_id()); ?> Image" src="<?php echo esc_url($design->getImageUrl()); ?>" />
                             <?php echo esc_html((null !== $design->get_title()) ? $design->get_title() : 'Custom Design ' . $design->get_design_id()); ?>
                         </a>
                         <div class="mystyle-design-author">Designed by: <?php echo esc_html($user->user_nicename); ?></div>

--- a/templates/design.php
+++ b/templates/design.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <p>
-	<img class="mystyle-centered" src="<?php echo esc_attr( $design->get_web_url() ); ?>"/>
+	<img class="mystyle-centered" src="<?php echo esc_attr( $design->getImageUrl() ); ?>"/>
 </p>
 <?php if ( null !== $design->get_print_url() ) { ?>
 	<ul class="mystyle-button-group">


### PR DESCRIPTION
1. For design thumbs, switch back from web filename to thumb when there’s _not_ a valid license. This is only applicable when the image URL contains underscores and “_thumb\” in the URL.
2. Stop additional API call every time and store "mystyle_license_status_" and "mystyle_last_update_datetime" in database.
3. Setup Cron job to locally store license status and update it daily.

### All Submissions:

* [x] Have you followed the [MyStyle Contributing guideline](https://github.com/mystyle-platform/mystyle-wp-custom-product-designer/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### How to test the changes in this Pull Request:

1. Manually change the value of "mystyle_license_status_" in database as valid/invalid then check the image.
2. Install "Advanced Cron Manager" plugin, for execute cron job (update_credentials_status)  manually.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

1. For design thumbs, switch back from web filename to thumb when there’s _not_ a valid license. This is only applicable when the image URL contains underscores and “_thumb\” in the URL.
2. Stop additional API call every time and store "mystyle_license_status_" and "mystyle_last_update_datetime" in database.
3. Setup Cron job to locally store license status and update it daily.
