### PR TITLE
Adding Design Collections links on logged-out design profile view

### DIFF
--- a/includes/shortcodes/class-mystyle-design-profile-shortcode.php
+++ b/includes/shortcodes/class-mystyle-design-profile-shortcode.php
@@ -88,7 +88,7 @@ abstract class MyStyle_Design_Profile_Shortcode {
 		$product_menu_type       = MyStyle_Options::get_design_profile_product_menu_type();
 		$show_add_to_cart_button = MyStyle_Design_Profile_Page::show_add_to_cart_button();
 		$design_tags             = MyStyle_DesignManager::get_design_tags( $design->get_design_id(), true );
-
+		$design_collections      =	MyStyle_DesignManager::get_design_collections( $design->get_design_id(), true );
 		// ---------- Call the view layer -------------------- //
 		ob_start();
 		require MYSTYLE_TEMPLATES . 'design-profile/profile.php';

--- a/templates/design-profile/profile.php
+++ b/templates/design-profile/profile.php
@@ -158,6 +158,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<a href="<?php echo esc_url( MyStyle_Design_Tag_Page::get_tag_url( $tag['slug'] ) ); ?>" title="<?php echo esc_attr( $tag['name'] ); ?> Design Tags"><?php echo esc_html( $tag['name'] ); ?></a>
 				<?php endforeach; ?>
 			</div>
+			<div class="design-collection">
+				Design Collections:
+				<?php foreach ( $design_collections  as $i => $tag ) : ?>
+					<?php
+					if ( $i > 0 ) {
+						echo ', ';}
+					?>
+					<a href="<?php echo esc_url( MyStyle_Design_Collection_Page::get_collection_url( $tag['slug'] ) ); ?>" title="<?php echo esc_attr( $tag['name'] ); ?> Design Tags"><?php echo esc_html( $tag['name'] ); ?></a>
+				<?php endforeach; ?>
+			</div>
 		<?php endif; ?>
 
 		<?php do_action( 'mystyle_design_profile_description_after', array( $design ) ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [MyStyle Contributing guideline](https://github.com/mystyle-platform/mystyle-wp-custom-product-designer/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adding Design Collections links on logged-out design profile view

### How to test the changes in this Pull Request:

1. Add a Design collection in design profile page
2. Go on logged-out design profile view
3. Scroll down and see design collection links 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Adding Design Collections links on logged-out design profile view.
